### PR TITLE
download file treats resource identifiers as strings

### DIFF
--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandler.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandler.java
@@ -57,7 +57,7 @@ public class CreatePresignedDownloadUrlHandler extends ApiGatewayHandler<Void, C
     protected CreatePresignedDownloadUrlResponse processInput(Void input, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
 
-        UUID identifier = RequestUtil.getIdentifier(requestInfo);
+        String identifier = RequestUtil.getIdentifier(requestInfo);
         Publication publication = publicationService.getPublication(identifier);
         authorizeIfNotPublished(requestInfo, publication);
 
@@ -69,7 +69,7 @@ public class CreatePresignedDownloadUrlHandler extends ApiGatewayHandler<Void, C
 
     private void authorizeIfNotPublished(RequestInfo requestInfo, Publication publication) throws ApiGatewayException {
         if (!isPublished(publication)) {
-            UUID identifier = RequestUtil.getIdentifier(requestInfo);
+            String identifier = RequestUtil.getIdentifier(requestInfo);
             String userId = RequestUtil.getUserIdOptional(requestInfo).orElse(null);
             authorize(identifier, userId, publication);
         }
@@ -101,7 +101,7 @@ public class CreatePresignedDownloadUrlHandler extends ApiGatewayHandler<Void, C
             .orElseThrow(() -> new FileNotFoundException(ERROR_MISSING_FILE_IN_PUBLICATION_FILE_SET));
     }
 
-    private void authorize(UUID identifier, String userId, Publication publication) throws ApiGatewayException {
+    private void authorize(String identifier, String userId, Publication publication) throws ApiGatewayException {
         if (isPublished(publication) || userIsOwner(userId, publication)) {
             return;
         }

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/RequestUtil.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/RequestUtil.java
@@ -1,13 +1,12 @@
 package no.unit.nva.download.publication.file;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Optional;
+import java.util.UUID;
 import no.unit.nva.download.publication.file.publication.exception.InputException;
 import nva.commons.exceptions.ApiGatewayException;
 import nva.commons.handlers.RequestInfo;
 import org.apache.http.HttpHeaders;
-
-import java.util.Optional;
-import java.util.UUID;
 
 public final class RequestUtil {
 
@@ -15,10 +14,11 @@ public final class RequestUtil {
     public static final String FILE_IDENTIFIER = "fileIdentifier";
     public static final String MISSING_AUTHORIZATION_IN_HEADERS = "Missing Authorization in Headers";
     public static final String IDENTIFIER_IS_NOT_A_VALID_UUID = "Identifier is not a valid UUID: ";
+    public static final String MISSING_RESOURCE_IDENTIFIER = "Missing Resource identifier";
     public static final String AUTHORIZER_CLAIMS = "/authorizer/claims/";
     public static final String CUSTOM_FEIDE_ID = "custom:feideId";
     public static final String MISSING_CLAIM_IN_REQUEST_CONTEXT =
-            "Missing claim in requestContext: ";
+        "Missing claim in requestContext: ";
 
     private RequestUtil() {
     }
@@ -32,14 +32,14 @@ public final class RequestUtil {
      */
     public static String getAuthorization(RequestInfo requestInfo) throws ApiGatewayException {
         return getAuthorizationOptional(requestInfo)
-                .orElseThrow(() -> new InputException(MISSING_AUTHORIZATION_IN_HEADERS, null));
+                   .orElseThrow(() -> new InputException(MISSING_AUTHORIZATION_IN_HEADERS, null));
     }
 
     /**
      * Get optional Authorization header from request.
      *
-     * @param requestInfo   requestInfo
-     * @return  optional Authorization header
+     * @param requestInfo requestInfo
+     * @return optional Authorization header
      */
     public static Optional<String> getAuthorizationOptional(RequestInfo requestInfo) {
         return Optional.ofNullable(requestInfo.getHeaders().get(HttpHeaders.AUTHORIZATION));
@@ -50,16 +50,12 @@ public final class RequestUtil {
      *
      * @param requestInfo requestInfo
      * @return the identifier
-     * @throws ApiGatewayException exception thrown if value is missing
      */
-    public static UUID getIdentifier(RequestInfo requestInfo) throws ApiGatewayException {
-        String identifier = null;
-        try {
-            identifier = requestInfo.getPathParameters().get(IDENTIFIER);
-            return UUID.fromString(identifier);
-        } catch (Exception e) {
-            throw new InputException(IDENTIFIER_IS_NOT_A_VALID_UUID + identifier, e);
-        }
+    public static String getIdentifier(RequestInfo requestInfo) {
+        return Optional.of(requestInfo)
+                   .map(RequestInfo::getPathParameters)
+                   .map(pathParameters -> pathParameters.get(IDENTIFIER))
+                   .orElseThrow(() -> new InputException(MISSING_RESOURCE_IDENTIFIER));
     }
 
     /**
@@ -79,7 +75,6 @@ public final class RequestUtil {
         }
     }
 
-
     /**
      * Get userId from requestContext authorizer claims.
      *
@@ -89,21 +84,20 @@ public final class RequestUtil {
      */
     public static String getUserId(RequestInfo requestInfo) throws ApiGatewayException {
         return getUserIdOptional(requestInfo)
-                .orElseThrow(() -> new InputException(MISSING_CLAIM_IN_REQUEST_CONTEXT + CUSTOM_FEIDE_ID, null));
+                   .orElseThrow(() -> new InputException(MISSING_CLAIM_IN_REQUEST_CONTEXT + CUSTOM_FEIDE_ID, null));
     }
 
     /**
      * Get optional userId from requestContext authorizer claims.
      *
-     * @param requestInfo   requestInfo
-     * @return  optional userId
+     * @param requestInfo requestInfo
+     * @return optional userId
      */
     public static Optional<String> getUserIdOptional(RequestInfo requestInfo) {
         JsonNode jsonNode = requestInfo.getRequestContext().at(AUTHORIZER_CLAIMS + CUSTOM_FEIDE_ID);
         if (!jsonNode.isMissingNode()) {
             return Optional.ofNullable(jsonNode.textValue());
         }
-        return  Optional.empty();
+        return Optional.empty();
     }
-
 }

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/exception/NotFoundException.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/exception/NotFoundException.java
@@ -3,13 +3,11 @@ package no.unit.nva.download.publication.file.exception;
 import nva.commons.exceptions.ApiGatewayException;
 import org.apache.http.HttpStatus;
 
-import java.util.UUID;
-
 public class NotFoundException extends ApiGatewayException {
 
     public static final String RESOURCE_NOT_FOUND = "Resource not found: ";
 
-    public NotFoundException(UUID identifier) {
+    public NotFoundException(String identifier) {
         super(RESOURCE_NOT_FOUND + identifier);
     }
 

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/RestPublicationService.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/RestPublicationService.java
@@ -2,7 +2,6 @@ package no.unit.nva.download.publication.file.publication;
 
 import static nva.commons.utils.attempt.Try.attempt;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mikael.urlbuilder.UrlBuilder;
@@ -11,7 +10,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Optional;
-import java.util.UUID;
 import no.unit.nva.download.publication.file.publication.exception.NoResponseException;
 import no.unit.nva.download.publication.file.publication.exception.NotFoundException;
 import no.unit.nva.model.Publication;
@@ -72,7 +70,7 @@ public class RestPublicationService {
      * @return A publication
      * @throws ApiGatewayException exception thrown if value is missing
      */
-    public Publication getPublication(UUID identifier)
+    public Publication getPublication(String identifier)
         throws ApiGatewayException {
 
         URI uri = buildUriToPublicationService(identifier);
@@ -80,7 +78,7 @@ public class RestPublicationService {
         return fetchPublicationFromService(identifier, uri, httpRequest);
     }
 
-    private Publication fetchPublicationFromService(UUID identifier, URI uri, HttpRequest httpRequest)
+    private Publication fetchPublicationFromService(String identifier, URI uri, HttpRequest httpRequest)
         throws ApiGatewayException {
 
         try {
@@ -90,7 +88,7 @@ public class RestPublicationService {
         }
     }
 
-    private Publication fetchPublicationFromService(UUID identifier, HttpRequest httpRequest)
+    private Publication fetchPublicationFromService(String identifier, HttpRequest httpRequest)
             throws java.io.IOException, InterruptedException, NotFoundException {
 
         HttpResponse<String> httpResponse = sendHttpRequest(httpRequest);
@@ -108,18 +106,18 @@ public class RestPublicationService {
         return new NoResponseException(ERROR_COMMUNICATING_WITH_REMOTE_SERVICE + uri.toString(), exception);
     }
 
-    private String extractExternalErrorMessage(UUID identifier, HttpResponse<String> httpResponse) {
+    private String extractExternalErrorMessage(String identifier, HttpResponse<String> httpResponse) {
         String externalErrorMessage = parseResponseBody(httpResponse.body())
             .map(Problem::getDetail)
             .orElse(ERROR_PUBLICATION_NOT_FOUND_FOR_IDENTIFIER + identifier);
         return decorateExternalErrorMessage(identifier, externalErrorMessage);
     }
 
-    private String decorateExternalErrorMessage(UUID identifier, String externalErrorMessage) {
+    private String decorateExternalErrorMessage(String identifier, String externalErrorMessage) {
         return String.join(ERROR_MESSAGE_DELIMITER, externalErrorDecoration(identifier), externalErrorMessage);
     }
 
-    private String externalErrorDecoration(UUID identifier) {
+    private String externalErrorDecoration(String identifier) {
         return EXTERNAL_ERROR_MESSAGE_DECORATION + identifier;
     }
 
@@ -145,11 +143,11 @@ public class RestPublicationService {
                 .build();
     }
 
-    private URI buildUriToPublicationService(UUID identifier) {
+    private URI buildUriToPublicationService(String identifier) {
         return UrlBuilder.empty()
             .withScheme(apiScheme)
             .withHost(apiHost)
-            .withPath(PATH + identifier.toString())
+            .withPath(PATH + identifier)
             .toUri();
     }
 }

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/exception/InputException.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/exception/InputException.java
@@ -1,16 +1,12 @@
 package no.unit.nva.download.publication.file.publication.exception;
 
-import nva.commons.exceptions.ApiGatewayException;
-import org.apache.http.HttpStatus;
+public class InputException extends RuntimeException {
 
-public class InputException extends ApiGatewayException {
-
-    public InputException(String message, Exception exception) {
-        super(exception, message);
+    public InputException(String message) {
+        super(message);
     }
 
-    @Override
-    protected Integer statusCode() {
-        return HttpStatus.SC_BAD_REQUEST;
+    public InputException(String message, Exception exception) {
+        super(message, exception);
     }
 }

--- a/create-presigned-download-url/src/test/java/no/unit/nva/download/publication/file/RequestUtilTest.java
+++ b/create-presigned-download-url/src/test/java/no/unit/nva/download/publication/file/RequestUtilTest.java
@@ -28,9 +28,9 @@ public class RequestUtilTest {
         RequestInfo requestInfo = new RequestInfo();
         requestInfo.setPathParameters(Map.of(RequestUtil.IDENTIFIER, uuid.toString()));
 
-        UUID identifier = RequestUtil.getIdentifier(requestInfo);
+        String identifier = RequestUtil.getIdentifier(requestInfo);
 
-        assertEquals(uuid, identifier);
+        assertEquals(uuid.toString(), identifier);
     }
 
     @Test

--- a/create-presigned-download-url/src/test/java/no/unit/nva/download/publication/file/publication/RestPublicationServiceTest.java
+++ b/create-presigned-download-url/src/test/java/no/unit/nva/download/publication/file/publication/RestPublicationServiceTest.java
@@ -53,7 +53,7 @@ public class RestPublicationServiceTest {
         RestPublicationService publicationService = new RestPublicationService(client, objectMapper, API_SCHEME,
             API_HOST);
 
-        assertThrows(NoResponseException.class, () -> publicationService.getPublication(UUID.randomUUID()));
+        assertThrows(NoResponseException.class, () -> publicationService.getPublication(UUID.randomUUID().toString()));
     }
 
     @Test
@@ -66,7 +66,7 @@ public class RestPublicationServiceTest {
         RestPublicationService publicationService = new RestPublicationService(client, objectMapper, API_SCHEME,
             API_HOST);
 
-        Publication publication = publicationService.getPublication(UUID.randomUUID());
+        Publication publication = publicationService.getPublication(UUID.randomUUID().toString());
 
         assertNotNull(publication);
     }
@@ -81,7 +81,7 @@ public class RestPublicationServiceTest {
         RestPublicationService publicationService = new RestPublicationService(client, objectMapper, API_SCHEME,
             API_HOST);
 
-        assertThrows(NotFoundException.class, () -> publicationService.getPublication(UUID.randomUUID()));
+        assertThrows(NotFoundException.class, () -> publicationService.getPublication(UUID.randomUUID().toString()));
     }
 
     @Test
@@ -96,7 +96,7 @@ public class RestPublicationServiceTest {
             API_HOST);
 
         NotFoundException actualException = assertThrows(NotFoundException.class,
-            () -> publicationService.getPublication(UUID.randomUUID()));
+            () -> publicationService.getPublication(UUID.randomUUID().toString()));
 
         assertThat(actualException.getMessage(), containsString(NOT_FOUND_ERROR_MESSAGE));
     }


### PR DESCRIPTION
Downloading file assumes that it knows the format of resource identifiers. For now we use Strings to remove this assumption. Later step will be that any other service (including downloading files) will handle on IDs (i.e. URIs) and not Identifiers (i.e. not URIs).