### PR TITLE
allowing contributor to fetch the same files as publication owner

### DIFF
--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandler.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandler.java
@@ -2,25 +2,17 @@ package no.unit.nva.download.publication.file;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 import static no.unit.nva.download.publication.file.RequestUtil.getFileIdentifier;
-import static no.unit.nva.download.publication.file.RequestUtil.getUser;
-import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE_EMBARGO;
-import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
-import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.github.bibsysdev.urlshortener.service.UriShortener;
 import com.github.bibsysdev.urlshortener.service.UriShortenerImpl;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.Optional;
 import java.util.UUID;
 import no.unit.nva.download.publication.file.aws.s3.AwsS3Service;
-import no.unit.nva.download.publication.file.exception.NotFoundException;
 import no.unit.nva.download.publication.file.publication.RestPublicationService;
-import no.unit.nva.download.publication.file.publication.exception.InputException;
 import no.unit.nva.download.publication.file.publication.model.File;
 import no.unit.nva.download.publication.file.publication.model.Publication;
-import no.unit.nva.download.publication.file.publication.model.PublicationStatusConstants;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -54,14 +46,12 @@ public class CreatePresignedDownloadUrlHandler extends ApiGatewayHandler<Void, P
      */
     @JacocoGenerated
     public CreatePresignedDownloadUrlHandler() {
-        this(new RestPublicationService(new Environment()),
-             new AwsS3Service(new Environment()),
-             new Environment(),
+        this(new RestPublicationService(new Environment()), new AwsS3Service(new Environment()), new Environment(),
              UriShortenerImpl.createDefault());
     }
 
     @Override
-    protected void validateRequest(Void unused, RequestInfo requestInfo, Context context) throws ApiGatewayException {
+    protected void validateRequest(Void unused, RequestInfo requestInfo, Context context) {
         //Do nothing
     }
 
@@ -70,17 +60,19 @@ public class CreatePresignedDownloadUrlHandler extends ApiGatewayHandler<Void, P
         throws ApiGatewayException {
 
         var publication = publicationService.getPublication(RequestUtil.getIdentifier(requestInfo));
-        var file = getFileInformation(publication, requestInfo);
+        var fileIdentifier = getFileIdentifier(requestInfo);
+
+        FileValidationUtil.create(fileIdentifier, publication).validateAccess(requestInfo);
+
+        return createPresignedUrl(publication, fileIdentifier);
+    }
+
+    private PresignedUri createPresignedUrl(Publication publication, UUID fileIdentifier) throws ApiGatewayException {
+        var file = publication.getFile(fileIdentifier);
         var expiration = defaultExpiration();
         var presignUriLong = getPresignedDownloadUrl(file, expiration);
         var shortenedPresignUri = getShortenedVersion(presignUriLong, expiration);
-        return new PresignedUri(presignUriLong, expiration.toInstant(),
-                                shortenedPresignUri);
-    }
-
-    private String getShortenedVersion(String presignUriLong, Date expiration) {
-        var shortenedUri = uriShortener.shorten(UriWrapper.fromUri(presignUriLong).getUri(), expiration.toInstant());
-        return shortenedUri.toString();
+        return new PresignedUri(presignUriLong, expiration.toInstant(), shortenedPresignUri);
     }
 
     @Override
@@ -88,62 +80,8 @@ public class CreatePresignedDownloadUrlHandler extends ApiGatewayHandler<Void, P
         return HTTP_OK;
     }
 
-    private File getFileInformation(Publication publication, RequestInfo requestInfo)
-        throws NotFoundException, InputException {
-
-        var fileIdentifier = getFileIdentifier(requestInfo);
-        if (publication.associatedArtifacts().isEmpty()) {
-            throw new NotFoundException(publication.identifier(), fileIdentifier);
-        }
-
-        return publication.associatedArtifacts().stream()
-                   .filter(File.class::isInstance)
-                   .map(File.class::cast)
-                   .filter(element -> findByIdentifier(fileIdentifier, element))
-                   .map(element -> getFile(element, publication, requestInfo))
-                   .filter(Optional::isPresent)
-                   .map(Optional::get)
-                   .findFirst()
-                   .orElseThrow(() -> new NotFoundException(publication.identifier(), fileIdentifier));
-    }
-
-    private boolean findByIdentifier(UUID fileIdentifier, File element) {
-        return fileIdentifier.equals(element.getIdentifier());
-    }
-
-    private boolean hasReadAccess(File file, Publication publication, RequestInfo requestInfo) {
-
-        var isThesisAndEmbargoThesisReader =
-            isThesis(publication) && requestInfo.userIsAuthorized(MANAGE_DEGREE_EMBARGO);
-        var isOwner = publication.resourceOwner().owner().equals(getUser(requestInfo));
-        var hasActiveEmbargo = file.hasActiveEmbargo();
-
-        if (hasActiveEmbargo) {
-            return isOwner || isThesisAndEmbargoThesisReader;
-        }
-
-        var isPublished = PublicationStatusConstants.PUBLISHED.equals(publication.status());
-        var isEditor = requestInfo.userIsAuthorized(MANAGE_RESOURCES_STANDARD);
-
-        return isOwner || isEditor || isPublished && file.isVisibleForNonOwner();
-    }
-
-    private Optional<File> getFile(File file, Publication publication, RequestInfo requestInfo) {
-        return hasReadAccess(file, publication, requestInfo)
-                   ? Optional.of(file)
-                   : Optional.empty();
-    }
-
-    private boolean isThesis(Publication publication) {
-        var kind = attempt(() -> publication
-                                     .entityDescription()
-                                     .reference()
-                                     .publicationInstance()).toOptional();
-        return kind.isPresent() && ("DegreeBachelor".equals(kind.get().type())
-                                    ||
-                                    "DegreeMaster".equals(kind.get().type())
-                                    ||
-                                    "DegreePhd".equals(kind.get().type()));
+    private String getShortenedVersion(String presignUriLong, Date expiration) {
+        return uriShortener.shorten(UriWrapper.fromUri(presignUriLong).getUri(), expiration.toInstant()).toString();
     }
 
     private String getPresignedDownloadUrl(File file, Date expiration) throws ApiGatewayException {

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandler.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandler.java
@@ -62,7 +62,7 @@ public class CreatePresignedDownloadUrlHandler extends ApiGatewayHandler<Void, P
         var publication = publicationService.getPublication(RequestUtil.getIdentifier(requestInfo));
         var fileIdentifier = getFileIdentifier(requestInfo);
 
-        FileValidationUtil.create(fileIdentifier, publication).validateAccess(requestInfo);
+        FileAccessValidationUtil.create(fileIdentifier, publication).validateAccess(requestInfo);
 
         return createPresignedUrl(publication, fileIdentifier);
     }

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/FileAccessValidationUtil.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/FileAccessValidationUtil.java
@@ -13,18 +13,18 @@ import no.unit.nva.download.publication.file.publication.model.PublicationStatus
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ForbiddenException;
 
-public class FileValidationUtil {
+public class FileAccessValidationUtil {
 
     private final UUID fileIdentifier;
     private final Publication publication;
 
-    public FileValidationUtil(UUID fileIdentifier, Publication publication) {
+    public FileAccessValidationUtil(UUID fileIdentifier, Publication publication) {
         this.fileIdentifier = fileIdentifier;
         this.publication = publication;
     }
 
-    public static FileValidationUtil create(UUID fileIdentifier, Publication publication) {
-        return new FileValidationUtil(fileIdentifier, publication);
+    public static FileAccessValidationUtil create(UUID fileIdentifier, Publication publication) {
+        return new FileAccessValidationUtil(fileIdentifier, publication);
     }
 
     public void validateAccess(RequestInfo requestInfo) throws NotFoundException, ForbiddenException {

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/FileAccessValidationUtil.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/FileAccessValidationUtil.java
@@ -82,6 +82,6 @@ public class FileAccessValidationUtil {
                    .map(File.class::cast)
                    .filter(file -> file.getIdentifier().equals(this.fileIdentifier))
                    .findFirst()
-                   .orElseThrow(() -> new NotFoundException(publication.identifier(), fileIdentifier));
+                   .orElseThrow(NotFoundException::new);
     }
 }

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/FileValidationUtil.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/FileValidationUtil.java
@@ -1,0 +1,87 @@
+package no.unit.nva.download.publication.file;
+
+import static no.unit.nva.download.publication.file.RequestUtil.getPersonCristinId;
+import static no.unit.nva.download.publication.file.RequestUtil.getUser;
+import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE_EMBARGO;
+import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_STANDARD;
+import java.util.UUID;
+import java.util.stream.Stream;
+import no.unit.nva.download.publication.file.exception.NotFoundException;
+import no.unit.nva.download.publication.file.publication.model.File;
+import no.unit.nva.download.publication.file.publication.model.Publication;
+import no.unit.nva.download.publication.file.publication.model.PublicationStatusConstants;
+import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.ForbiddenException;
+
+public class FileValidationUtil {
+
+    private final UUID fileIdentifier;
+    private final Publication publication;
+
+    public FileValidationUtil(UUID fileIdentifier, Publication publication) {
+        this.fileIdentifier = fileIdentifier;
+        this.publication = publication;
+    }
+
+    public static FileValidationUtil create(UUID fileIdentifier, Publication publication) {
+        return new FileValidationUtil(fileIdentifier, publication);
+    }
+
+    public void validateAccess(RequestInfo requestInfo) throws NotFoundException, ForbiddenException {
+        if (!hasAccess(requestInfo)) {
+            throw new ForbiddenException();
+        }
+    }
+
+    private boolean hasAccess(RequestInfo requestInfo) throws NotFoundException {
+        var file = getFile();
+        return file.hasActiveEmbargo()
+                   ? hasAccessToFileWithActiveEmbargo(requestInfo)
+                   : hasAccessToFile(file, requestInfo);
+    }
+
+    private boolean hasAccessToFile(File file, RequestInfo requestInfo) {
+        return Stream.of(isOwner(publication, requestInfo),
+                         isContributor(publication, requestInfo),
+                         isEditor(requestInfo),
+                         fileIsVisibleForNonOwner(file, publication))
+                   .anyMatch(Boolean::booleanValue);
+    }
+
+    private boolean isContributor(Publication publication, RequestInfo requestInfo) {
+        return getPersonCristinId(requestInfo).map(publication::hasContributorWithId).orElse(false);
+    }
+
+    private boolean isOwner(Publication publication, RequestInfo requestInfo) {
+        return publication.resourceOwner().owner().equals(getUser(requestInfo));
+    }
+
+    private boolean isEditor(RequestInfo requestInfo) {
+        return requestInfo.userIsAuthorized(MANAGE_RESOURCES_STANDARD);
+    }
+
+    private boolean fileIsVisibleForNonOwner(File file, Publication publication) {
+        return PublicationStatusConstants.PUBLISHED.equals(publication.status()) && file.isVisibleForNonOwner();
+    }
+
+    private boolean hasAccessToFileWithActiveEmbargo(RequestInfo requestInfo) {
+        return Stream.of(isOwner(publication, requestInfo),
+                         isContributor(publication, requestInfo),
+                         canManageDegreeWithEmbargo(requestInfo))
+                   .anyMatch(Boolean::booleanValue);
+    }
+
+    private boolean canManageDegreeWithEmbargo(RequestInfo requestInfo) {
+        return publication.isThesis() && requestInfo.userIsAuthorized(MANAGE_DEGREE_EMBARGO);
+    }
+
+    private File getFile() throws NotFoundException {
+        return publication.associatedArtifacts()
+                   .stream()
+                   .filter(File.class::isInstance)
+                   .map(File.class::cast)
+                   .filter(file -> file.getIdentifier().equals(this.fileIdentifier))
+                   .findFirst()
+                   .orElseThrow(() -> new NotFoundException(publication.identifier(), fileIdentifier));
+    }
+}

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/RequestUtil.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/RequestUtil.java
@@ -1,5 +1,6 @@
 package no.unit.nva.download.publication.file;
 
+import java.net.URI;
 import no.unit.nva.download.publication.file.publication.exception.InputException;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.core.StringUtils;
@@ -71,5 +72,9 @@ public final class RequestUtil {
 
     public static String getUser(RequestInfo requestInfo) {
         return attempt(requestInfo::getUserName).orElse(user -> ANONYMOUS);
+    }
+
+    public static Optional<URI> getPersonCristinId(RequestInfo requestInfo) {
+        return attempt(requestInfo::getPersonCristinId).toOptional();
     }
 }

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/exception/NotFoundException.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/exception/NotFoundException.java
@@ -1,18 +1,14 @@
 package no.unit.nva.download.publication.file.exception;
 
-
-import no.unit.nva.identifiers.SortableIdentifier;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import org.apache.http.HttpStatus;
 
-import java.util.UUID;
-
 public class NotFoundException extends ApiGatewayException {
 
-    public static final String ERROR_TEMPLATE = "The requested resource \"%s/files/%s\" was not found";
+    public static final String ERROR_TEMPLATE = "The requested resource was not found";
 
-    public NotFoundException(SortableIdentifier resource, UUID file)  {
-        super(String.format(ERROR_TEMPLATE, resource, file));
+    public NotFoundException()  {
+        super(ERROR_TEMPLATE);
     }
 
     @Override

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/exception/NotFoundException.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/exception/NotFoundException.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public class NotFoundException extends ApiGatewayException {
 
-    public static final String ERROR_TEMPLATE = "Requested resource \"%s/files/%s\" was not found";
+    public static final String ERROR_TEMPLATE = "The requested resource \"%s/files/%s\" was not found";
 
     public NotFoundException(SortableIdentifier resource, UUID file)  {
         super(String.format(ERROR_TEMPLATE, resource, file));

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/exception/NotFoundException.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/exception/NotFoundException.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public class NotFoundException extends ApiGatewayException {
 
-    public static final String ERROR_TEMPLATE = "Requested resource \"%s/files/%s\" was found";
+    public static final String ERROR_TEMPLATE = "Requested resource \"%s/files/%s\" was not found";
 
     public NotFoundException(SortableIdentifier resource, UUID file)  {
         super(String.format(ERROR_TEMPLATE, resource, file));

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/Contributor.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/Contributor.java
@@ -1,0 +1,5 @@
+package no.unit.nva.download.publication.file.publication.model;
+
+public record Contributor(Identity identity) {
+
+}

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/EntityDescription.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/EntityDescription.java
@@ -2,8 +2,9 @@ package no.unit.nva.download.publication.file.publication.model;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import java.util.List;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
-public record EntityDescription(Reference reference) {
+public record EntityDescription(Reference reference, List<Contributor> contributors) {
 
 }

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/Identity.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/Identity.java
@@ -1,0 +1,7 @@
+package no.unit.nva.download.publication.file.publication.model;
+
+import java.net.URI;
+
+public record Identity(URI id) {
+
+}

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/Publication.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/Publication.java
@@ -1,7 +1,10 @@
 package no.unit.nva.download.publication.file.publication.model;
 
+import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.net.URI;
 import java.util.List;
+import java.util.UUID;
 import no.unit.nva.identifiers.SortableIdentifier;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -11,4 +14,26 @@ public record Publication(SortableIdentifier identifier,
                           EntityDescription entityDescription,
                           List<AssociatedArtifact> associatedArtifacts) {
 
+    public boolean isThesis() {
+        return attempt(() -> entityDescription.reference().publicationInstance()).toOptional()
+                   .map(PublicationInstance::isThesis)
+                   .orElse(false);
+    }
+
+    public File getFile(UUID fileIdentifier) {
+        return associatedArtifacts
+                   .stream()
+                   .filter(File.class::isInstance)
+                   .map(File.class::cast)
+                   .filter(f -> f.getIdentifier().equals(fileIdentifier))
+                   .findFirst()
+                   .orElseThrow();
+    }
+
+    public boolean hasContributorWithId(URI id) {
+        return entityDescription.contributors().stream()
+                   .map(Contributor::identity)
+                   .map(Identity::id)
+                   .anyMatch(id::equals);
+    }
 }

--- a/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/PublicationInstance.java
+++ b/create-presigned-download-url/src/main/java/no/unit/nva/download/publication/file/publication/model/PublicationInstance.java
@@ -1,5 +1,12 @@
 package no.unit.nva.download.publication.file.publication.model;
 
+import java.util.Set;
+
 public record PublicationInstance(String type) {
 
+    private static final Set<String> THESIS_TYPES = Set.of("DegreeBachelor", "DegreeMaster", "DegreePhd");
+
+    public boolean isThesis() {
+        return THESIS_TYPES.contains(type);
+    }
 }

--- a/create-presigned-download-url/src/test/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandlerTest.java
+++ b/create-presigned-download-url/src/test/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandlerTest.java
@@ -10,6 +10,7 @@ import static no.unit.nva.download.publication.file.publication.RestPublicationS
 import static no.unit.nva.download.publication.file.publication.RestPublicationService.EXTERNAL_ERROR_MESSAGE_DECORATION;
 import static no.unit.nva.download.publication.file.publication.model.PublicationStatusConstants.DRAFT;
 import static no.unit.nva.download.publication.file.publication.model.PublicationStatusConstants.PUBLISHED;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static no.unit.nva.testutils.TestHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
 import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE_EMBARGO;
@@ -19,6 +20,7 @@ import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.HttpStatus.SC_BAD_GATEWAY;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
@@ -33,6 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.zalando.problem.Status.BAD_GATEWAY;
 import static org.zalando.problem.Status.BAD_REQUEST;
+import static org.zalando.problem.Status.FORBIDDEN;
 import static org.zalando.problem.Status.NOT_FOUND;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.kms.model.NotFoundException;
@@ -53,12 +56,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import no.unit.nva.download.publication.file.aws.s3.AwsS3Service;
 import no.unit.nva.download.publication.file.publication.RestPublicationService;
 import no.unit.nva.download.publication.file.publication.model.AssociatedLink;
+import no.unit.nva.download.publication.file.publication.model.Contributor;
 import no.unit.nva.download.publication.file.publication.model.EntityDescription;
 import no.unit.nva.download.publication.file.publication.model.File;
+import no.unit.nva.download.publication.file.publication.model.Identity;
 import no.unit.nva.download.publication.file.publication.model.NullAssociatedArtifact;
 import no.unit.nva.download.publication.file.publication.model.Publication;
 import no.unit.nva.download.publication.file.publication.model.PublicationInstance;
@@ -117,9 +124,9 @@ class CreatePresignedDownloadUrlHandlerTest {
         output = new ByteArrayOutputStream();
     }
 
-    @ParameterizedTest(name = "Should return not found when user is not owner and publication is unpublished")
+    @ParameterizedTest(name = "Should return Forbidden when user is not owner and publication is unpublished")
     @MethodSource("fileTypeSupplier")
-    void shouldReturnNotFoundWhenUserIsNotOwnerAndPublicationIsUnpublished(File file) throws IOException,
+    void shouldReturnForbiddenWhenUserIsNotOwnerAndPublicationIsUnpublished(File file) throws IOException,
                                                                                              InterruptedException {
         var s3Service = getAwsS3ServiceReturningPresignedUrl();
         var publication = buildPublication(DRAFT, file);
@@ -130,15 +137,14 @@ class CreatePresignedDownloadUrlHandlerTest {
             createRequest(NON_OWNER, publication.identifier(), file.getIdentifier()), output, context);
 
         var gatewayResponse = GatewayResponse.fromString(output.toString(), Problem.class);
-        assertBasicRestRequirements(gatewayResponse, SC_NOT_FOUND, APPLICATION_PROBLEM_JSON);
-        assertProblemEquivalence(gatewayResponse, getNotFoundPublicationServiceResponse(
-            notFoundError(publication.identifier(), file.getIdentifier())));
+        assertBasicRestRequirements(gatewayResponse, SC_FORBIDDEN, APPLICATION_PROBLEM_JSON);
+        assertProblemEquivalence(gatewayResponse, getForbiddenProblem());
     }
 
     @ParameterizedTest(
         name = "Files which is not draft but from a type requiring elevated rights is not downloadable by non owner")
     @MethodSource("fileTypeSupplierRequiringElevatedRights")
-    void handlerReturnsNotFoundForFilesWhichIsNotDraftButHasTypeRequiringElevationAndIsNonOwner(File file)
+    void handlerReturnsForbiddenForFilesWhichIsNotDraftButHasTypeRequiringElevationAndIsNonOwner(File file)
         throws IOException, InterruptedException {
         AwsS3Service s3Service = getAwsS3ServiceReturningPresignedUrl();
         var publication = buildPublication(PUBLISHED, file);
@@ -149,9 +155,8 @@ class CreatePresignedDownloadUrlHandlerTest {
             createRequest(NON_OWNER, publication.identifier(), file.getIdentifier()), output, context);
 
         var gatewayResponse = GatewayResponse.fromString(output.toString(), Problem.class);
-        assertBasicRestRequirements(gatewayResponse, SC_NOT_FOUND, APPLICATION_PROBLEM_JSON);
-        assertProblemEquivalence(gatewayResponse, getNotFoundPublicationServiceResponse(
-            notFoundError(publication.identifier(), file.getIdentifier())));
+        assertBasicRestRequirements(gatewayResponse, SC_FORBIDDEN, APPLICATION_PROBLEM_JSON);
+        assertProblemEquivalence(gatewayResponse, getForbiddenProblem());
     }
 
     @Test
@@ -356,7 +361,7 @@ class CreatePresignedDownloadUrlHandlerTest {
     }
 
     @Test
-    void shouldReturnNotFoundOnAnonymousRequestForDraftPublication()
+    void shouldReturnForbiddenOnAnonymousRequestForDraftPublication()
         throws IOException, InterruptedException {
         var publication = buildPublication(DRAFT, fileWithoutEmbargo(APPLICATION_PDF, FILE_IDENTIFIER));
         var publicationService = mockSuccessfulPublicationRequest(dtoObjectMapper.writeValueAsString(publication));
@@ -368,9 +373,8 @@ class CreatePresignedDownloadUrlHandlerTest {
         handler.handleRequest(createAnonymousRequest(publication.identifier()), output, context);
 
         var gatewayResponse = GatewayResponse.fromOutputStream(output, Problem.class);
-        assertBasicRestRequirements(gatewayResponse, SC_NOT_FOUND, APPLICATION_PROBLEM_JSON);
-        assertProblemEquivalence(gatewayResponse, getNotFoundPublicationServiceResponse(
-            notFoundError(publication.identifier(), FILE_IDENTIFIER)));
+        assertBasicRestRequirements(gatewayResponse, SC_FORBIDDEN, APPLICATION_PROBLEM_JSON);
+        assertProblemEquivalence(gatewayResponse, getForbiddenProblem());
     }
 
     @ParameterizedTest
@@ -430,7 +434,7 @@ class CreatePresignedDownloadUrlHandlerTest {
                                      + " " + EASY_TO_SEE + publicationIdentifier));
     }
 
-    @ParameterizedTest(name = "Should return Not Found when requester is not owner and embargo is in place")
+    @ParameterizedTest(name = "Should return Forbidden when requester is not owner and embargo is in place")
     @MethodSource("nonOwnerProvider")
     void shouldDisallowDownloadByNonOwnerWhenEmbargoDateHasNotPassed(InputStream request) throws IOException,
                                                                                                  InterruptedException {
@@ -441,12 +445,11 @@ class CreatePresignedDownloadUrlHandlerTest {
                                                             new FakeUriShortener());
         handler.handleRequest(request, output, context);
         var gatewayResponse = GatewayResponse.fromOutputStream(output, Problem.class);
-        assertBasicRestRequirements(gatewayResponse, SC_NOT_FOUND, APPLICATION_PROBLEM_JSON);
-        assertProblemEquivalence(gatewayResponse, getNotFoundPublicationServiceResponse(
-            notFoundError(publication.identifier(), FILE_IDENTIFIER)));
+        assertBasicRestRequirements(gatewayResponse, SC_FORBIDDEN, APPLICATION_PROBLEM_JSON);
+        assertProblemEquivalence(gatewayResponse, getForbiddenProblem());
     }
 
-    @ParameterizedTest(name = "Should return Not Found when requester is not owner and file is administrative "
+    @ParameterizedTest(name = "Should return Forbidden when requester is not owner and file is administrative "
                               + "agreement")
     @MethodSource("nonOwnerProvider")
     void shouldDisallowDownloadByNonOwnerWhenFileHasIsAdministrativeAgreement(InputStream request)
@@ -458,9 +461,8 @@ class CreatePresignedDownloadUrlHandlerTest {
                                                             new FakeUriShortener());
         handler.handleRequest(request, output, context);
         var gatewayResponse = GatewayResponse.fromOutputStream(output, Problem.class);
-        assertBasicRestRequirements(gatewayResponse, SC_NOT_FOUND, APPLICATION_PROBLEM_JSON);
-        assertProblemEquivalence(gatewayResponse, getNotFoundPublicationServiceResponse(
-            notFoundError(publication.identifier(), FILE_IDENTIFIER)));
+        assertBasicRestRequirements(gatewayResponse, SC_FORBIDDEN, APPLICATION_PROBLEM_JSON);
+        assertProblemEquivalence(gatewayResponse, getForbiddenProblem());
     }
 
     @Test
@@ -482,6 +484,41 @@ class CreatePresignedDownloadUrlHandlerTest {
 
         var gatewayResponse = GatewayResponse.fromOutputStream(output, Problem.class);
         assertBasicRestRequirements(gatewayResponse, SC_INTERNAL_SERVER_ERROR, APPLICATION_PROBLEM_JSON);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("fileTypeSupplier")
+    void handlerReturnsOkResponseWhenContributorWithCristinIdRequestsFile(File file) throws IOException,
+                                                                                      InterruptedException {
+        var publication = buildPublication(PUBLISHED, file);
+        var publicationService = mockSuccessfulPublicationRequest(dtoObjectMapper.writeValueAsString(publication));
+        var s3Service = getAwsS3ServiceReturningPresignedUrl();
+        var handler = new CreatePresignedDownloadUrlHandler(publicationService, s3Service, mockEnvironment(),
+                                                            new FakeUriShortener());
+        var contributorCristinId = publication.entityDescription().contributors().get(0).identity().id();
+        var request = userWithCristinIdRequestsFile(contributorCristinId, publication.identifier(), file.getIdentifier());
+        handler.handleRequest(request, output, context);
+        var gatewayResponse = GatewayResponse.fromString(output.toString(), PresignedUri.class);
+
+        assertBasicRestRequirements(gatewayResponse, SC_OK, APPLICATION_JSON);
+        assertExpectedResponseBody(gatewayResponse);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("fileTypeSupplierRequiringElevatedRights")
+    void handlerReturnsForbiddenResponseWhenContributorWithoutCristinIdRequestsFile(File file) throws IOException,
+                                                                                            InterruptedException {
+        var publication = buildPublication(PUBLISHED, file);
+        var publicationService = mockSuccessfulPublicationRequest(dtoObjectMapper.writeValueAsString(publication));
+        var s3Service = getAwsS3ServiceReturningPresignedUrl();
+        var handler = new CreatePresignedDownloadUrlHandler(publicationService, s3Service, mockEnvironment(),
+                                                            new FakeUriShortener());
+        var request = userWithCristinIdRequestsFile(randomUri(), publication.identifier(), file.getIdentifier());
+        handler.handleRequest(request, output, context);
+        var gatewayResponse = GatewayResponse.fromString(output.toString(), Problem.class);
+
+        assertBasicRestRequirements(gatewayResponse, SC_FORBIDDEN, APPLICATION_PROBLEM_JSON);
+        assertProblemEquivalence(gatewayResponse, getForbiddenProblem());
     }
 
     private static Stream<String> userSupplier() {
@@ -639,6 +676,14 @@ class CreatePresignedDownloadUrlHandlerTest {
                    .build();
     }
 
+    private Problem getForbiddenProblem() {
+        return Problem.builder()
+                   .withStatus(FORBIDDEN)
+                   .withTitle(FORBIDDEN.getReasonPhrase())
+                   .withDetail("Forbidden")
+                   .build();
+    }
+
     private String notFoundError(SortableIdentifier publicationIdentifier, UUID someRandomIdentifier) {
         return String.format(ERROR_TEMPLATE, publicationIdentifier, someRandomIdentifier);
     }
@@ -715,12 +760,21 @@ class CreatePresignedDownloadUrlHandlerTest {
 
     private Publication buildPublication(String status, File file) {
         var publicationInstanceType = file.hasActiveEmbargo() ? "DegreeMaster" : "AcademicMonograph";
-        var entityDescription = new EntityDescription(new Reference(new PublicationInstance(publicationInstanceType)));
+        var entityDescription = new EntityDescription(new Reference(new PublicationInstance(publicationInstanceType)),
+                                                      randomContributors());
         return new Publication(SOME_RANDOM_IDENTIFIER,
                                status,
                                new ResourceOwner("myUsername",
                                                  URI.create("https://my.affiliation.com")),
                                entityDescription, Collections.singletonList(file));
+    }
+
+    private List<Contributor> randomContributors() {
+        return IntStream.of(5).boxed().map(i -> randomContributor()).collect(Collectors.toList());
+    }
+
+    private Contributor randomContributor() {
+        return new Contributor(new Identity(randomUri()));
     }
 
     private Publication buildPublishedPublicationWithoutFiles() {
@@ -783,6 +837,18 @@ class CreatePresignedDownloadUrlHandlerTest {
                    .withHeaders(Map.of(AUTHORIZATION, SOME_API_KEY))
                    .withCurrentCustomer(randomUri())
                    .withUserName(user)
+                   .withPathParameters(Map.of(IDENTIFIER, identifier.toString(),
+                                              IDENTIFIER_FILE, fileIdentifier.toString()))
+                   .build();
+    }
+
+    private InputStream userWithCristinIdRequestsFile(URI personCristinId, SortableIdentifier identifier, UUID fileIdentifier)
+        throws IOException {
+        return new HandlerRequestBuilder<Void>(dtoObjectMapper)
+                   .withHeaders(Map.of(AUTHORIZATION, SOME_API_KEY))
+                   .withCurrentCustomer(randomUri())
+                   .withUserName(randomString())
+                   .withPersonCristinId(personCristinId)
                    .withPathParameters(Map.of(IDENTIFIER, identifier.toString(),
                                               IDENTIFIER_FILE, fileIdentifier.toString()))
                    .build();

--- a/create-presigned-download-url/src/test/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandlerTest.java
+++ b/create-presigned-download-url/src/test/java/no/unit/nva/download/publication/file/CreatePresignedDownloadUrlHandlerTest.java
@@ -513,7 +513,8 @@ class CreatePresignedDownloadUrlHandlerTest {
         var s3Service = getAwsS3ServiceReturningPresignedUrl();
         var handler = new CreatePresignedDownloadUrlHandler(publicationService, s3Service, mockEnvironment(),
                                                             new FakeUriShortener());
-        var request = userWithCristinIdRequestsFile(randomUri(), publication.identifier(), file.getIdentifier());
+        var notContributorCristinId = randomUri();
+        var request = userWithCristinIdRequestsFile(notContributorCristinId, publication.identifier(), file.getIdentifier());
         handler.handleRequest(request, output, context);
         var gatewayResponse = GatewayResponse.fromString(output.toString(), Problem.class);
 


### PR DESCRIPTION
Refactoring DonwnloadFile handler. Moving all access validation to new class. Allowing contributor to fetch the same files as publicationOwner can fetch. Returning forbidden instead of Not Found when user has no access to file.